### PR TITLE
DTYPE for initializer class

### DIFF
--- a/stork/connections.py
+++ b/stork/connections.py
@@ -36,7 +36,7 @@ class BaseConnection(core.NetworkNode):
 
         if constraints is None:
             self.constraints = []
-        elif type(constraints) == list:
+        elif isinstance(constraints, list):
             self.constraints = constraints
         elif issubclass(type(constraints), stork_constraints.WeightConstraint):
             self.constraints = [constraints]
@@ -97,7 +97,7 @@ class Connection(BaseConnection):
         super().configure(batch_size, nb_steps, time_step, device, dtype)
 
     def add_diagonal_structure(self, width=1.0, ampl=1.0):
-        if type(self.op) != nn.Linear:
+        if not isinstance(self.op, nn.Linear):
             raise ValueError("Expected op to be nn.Linear to add diagonal structure.")
         A = np.zeros(self.op.weight.shape)
         x = np.linspace(0, A.shape[0], A.shape[1])

--- a/stork/initializers.py
+++ b/stork/initializers.py
@@ -51,12 +51,13 @@ class Initializer:
     """
 
     def __init__(
-        self, scaling="1/sqrt(k)", sparseness=1.0, bias_scale=1.0, bias_mean=0.0
+        self, scaling="1/sqrt(k)", sparseness=1.0, bias_scale=1.0, bias_mean=0.0, dtype=torch.float32
     ):
         self.scaling = scaling
         self.sparseness = sparseness
         self.bias_scale = bias_scale
         self.bias_mean = bias_mean
+        self.dtype = dtype
 
     def initialize(self, target):
         if isinstance(target, connections.BaseConnection):
@@ -143,7 +144,7 @@ class Initializer:
 
         # set weights
         with torch.no_grad():
-            connection.op.weight.data = weights
+            connection.op.weight.data = weights.type(self.dtype)
 
     def _set_biases(self, connection):
         """
@@ -159,6 +160,7 @@ class Initializer:
                 connection.op.bias.uniform_(
                     -bound + self.bias_mean, bound + self.bias_mean
                 )
+                connection.op.bias.data = connection.op.bias.data.type(self.dtype)
 
     def _get_weights(self, *params):
         raise NotImplementedError


### PR DESCRIPTION
- Minor linting of type checks in connections module
- Added `dtype` attribute to initializer base class & consider it in setting of weights and biases