### PR TITLE
New features & minor patches for CST-decoding application

### DIFF
--- a/stork/core.py
+++ b/stork/core.py
@@ -29,6 +29,9 @@ class NetworkNode(nn.Module):
         self.time_step = time_step
         self.device = device
         self.dtype = dtype
+        
+    def set_nb_steps(self, nb_steps):
+        self.nb_steps = nb_steps
 
     def remove_regularizers(self):
         self.regularizers = []

--- a/stork/core.py
+++ b/stork/core.py
@@ -35,3 +35,6 @@ class NetworkNode(nn.Module):
 
     def remove_regularizers(self):
         self.regularizers = []
+
+    def set_dtype(self, dtype):
+        self.dtype = dtype

--- a/stork/datasets.py
+++ b/stork/datasets.py
@@ -837,7 +837,7 @@ class RasDataset(SpikingDataset):
 
         times = times.long()
 
-        X = torch.zeros((self.nb_steps, self.nb_units))
+        X = torch.zeros((self.nb_steps, self.nb_units), dtype=self.dtype)
         X[times, units] = 1.0
         y = self.labels[index]
 

--- a/stork/datasets.py
+++ b/stork/datasets.py
@@ -779,6 +779,8 @@ class RasDataset(SpikingDataset):
         p_insert=0.0,
         sigma_t=0.0,
         time_scale=1,
+        data_augmentation=False,
+        dtype=torch.long,
     ):
         """
         This converter provides an interface for standard Ras datasets to dense tensor format.
@@ -797,6 +799,7 @@ class RasDataset(SpikingDataset):
             p_insert=p_insert,
             sigma_t=sigma_t,
             time_scale=time_scale,
+            data_augmentation=data_augmentation
         )
 
         data, labels = dataset
@@ -812,8 +815,9 @@ class RasDataset(SpikingDataset):
 
         self.data = Xscaled
         self.labels = labels
+        self.dtype = dtype
         if type(self.labels) == torch.tensor:
-            self.labels = torch.cast(labels, dtype=torch.long)
+            self.labels = torch.cast(labels, dtype=dtype)
 
     def __len__(self):
         "Returns the total number of samples in dataset"

--- a/stork/datasets.py
+++ b/stork/datasets.py
@@ -632,6 +632,12 @@ class SpikingDataset(torch.utils.data.Dataset):
         sigma_u=0.0,
         sigma_u_uniform=0.0,
         time_scale=1,
+        data_augmentation=True, 
+        # Before, data_augmentation was hardcoded to True in the __init__ method,
+        # thus this defaults to True if not specified.
+        # Note that with the default sigma_t=0.0, sigma_u=0.0, 
+        # sigma_u_uniform=0.0, p_drop=0.0, p_insert=0.0,
+        # the data_augmentation parameter has no effect.
     ):
         """
         This converter provides an interface for standard spiking datasets
@@ -654,7 +660,7 @@ class SpikingDataset(torch.utils.data.Dataset):
         self.nb_steps = nb_steps
         self.nb_units = nb_units
         self.nb_insert = int(self.p_insert * self.nb_steps * self.nb_units)
-        self.data_augmentation = True
+        self.data_augmentation = data_augmentation
 
     def add_noise(self, times, units):
         """

--- a/stork/generators.py
+++ b/stork/generators.py
@@ -39,9 +39,10 @@ class StandardGenerator(DataGenerator):
     Provides a new transitional generator class based on the Torch Dataset/Loader formalism.
     """
 
-    def __init__(self, nb_workers=1, persistent_workers=True):
+    def __init__(self, nb_workers=1, persistent_workers=True, worker_init_fn=None):
         self.nb_workers = nb_workers
         self.persistent_workers = persistent_workers
+        self.worker_init_fn = worker_init_fn
 
     def __call__(self, dataset, shuffle=True):
         return torch.utils.data.DataLoader(
@@ -50,6 +51,7 @@ class StandardGenerator(DataGenerator):
             shuffle=shuffle,
             num_workers=self.nb_workers,
             persistent_workers=self.persistent_workers,
+            worker_init_fn=self.worker_init_fn,
         )
 
 

--- a/stork/models.py
+++ b/stork/models.py
@@ -103,6 +103,26 @@ class RecurrentSpikingModel(nn.Module):
         self.configure_scheduler(self.scheduler_class, self.scheduler_kwargs)
         
         self.to(self.device)
+        
+        
+    def set_nb_steps(self, nb_time_steps):
+        self.nb_time_steps = nb_time_steps
+        
+        # configure data generator
+        self.data_generator_.configure(
+            self.batch_size,
+            self.nb_time_steps,
+            self.nb_inputs,
+            self.time_step,
+            device=self.device,
+            dtype=self.dtype,
+        )
+        
+        for g in self.groups:
+            g.set_nb_steps(nb_time_steps)
+            
+        self.reset_states()
+
 
     def time_rescale(self, time_step=1e-3, batch_size=None):
         """Saves the model then re-configures it with the old hyper parameters, but the new timestep.

--- a/stork/models.py
+++ b/stork/models.py
@@ -635,3 +635,34 @@ class RecurrentSpikingModel(nn.Module):
         print("\n## Connections")
         for con in self.connections:
             print(con)
+
+    
+    def set_dtype(self, dtype):
+        self.dtype = dtype
+        
+        for g in self.groups:
+            g.set_dtype(dtype)
+        for c in self.connections:
+            c.set_dtype(dtype)
+            
+        self.to(self.device)
+        return self
+    
+
+    def half(self):
+        """ 
+        Convert model to half precision. 
+        Because stork does not treat group states as parameters,
+        we have to convert the model to half precision manually.
+        """
+        
+        # Convert group states to half precision
+        for group in self.groups:
+            group.half()
+
+        # This will convert parameters to half precision
+        super().half()
+        
+        self.set_dtype(torch.float16)
+         
+        return self

--- a/stork/models.py
+++ b/stork/models.py
@@ -365,6 +365,13 @@ class RecurrentSpikingModel(nn.Module):
             s = s + " %s=%.3g" % (name, val)
         return s
 
+    def get_metrics_dict(self, metrics_array, prefix="", postfix=""):
+        s = {}
+        names = self.get_metric_names(prefix, postfix)
+        for val, name in zip(metrics_array, names):
+            s[name] = val
+        return s
+
     def get_metrics_history_dict(self, metrics_array, prefix="", postfix=""):
         " Create metrics history dict. " ""
         s = ""

--- a/stork/nodes/base.py
+++ b/stork/nodes/base.py
@@ -145,5 +145,10 @@ class CellGroup(core.NetworkNode):
     def get_out_channels(self):
         return self.shape[0]
 
+    def half(self):
+        """ Convert all states to half precision """
+        for key in self.states:
+            self.states[key] = self.states[key].to(dtype=torch.float16)
+                
     def __call__(self, inputs):
         raise NotImplementedError

--- a/stork/nodes/input/base.py
+++ b/stork/nodes/input/base.py
@@ -6,8 +6,8 @@ from stork.nodes.base import CellGroup
 class InputGroup(CellGroup):
     """A special group which is used to supply batched dense tensor input to the network via its feed_data function."""
 
-    def __init__(self, shape, name="Input"):
-        super(InputGroup, self).__init__(shape, name=name)
+    def __init__(self, shape, name="Input", **kwargs):
+        super(InputGroup, self).__init__(shape, name=name, **kwargs)
 
     def reset_state(self, batch_size=None):
         super().reset_state(batch_size)


### PR DESCRIPTION
Collection of features, convenience functions & minor bug fixes as part of the publication of recurrent SNNs for decoding of cortical spike trains.

These additions are necessary to run the networks implemented in https://github.com/fmi-basel/neural-decoding-RSNN.

**New features:**
- Support for learning rate schedulers
- Support for half-precision models


**Minor patches:**
- `RasDataset` now supports custom dtypes (needed for half precision models)
- `RasDataset` correctly passes the `data_augmentation` argument on
- `data_augmentation` not hardcoded as `True` in `SpikingDataset` anymore
- `InputGroup` passes a `kwargs` dict to `CellGroup` (this enables dropout for input layers)
- `StandardGenerator` now passes on a `worker_init_fn` argument that can be used for reproducible multi-process data loading by providing a random seed (see https://pytorch.org/docs/stable/notes/randomness.html)
- `nb_time_steps` can be independently set without re-configuring the model now
